### PR TITLE
Typo fix on NODE_SEED

### DIFF
--- a/stellar-core-validator-mini-instance-example.cfg
+++ b/stellar-core-validator-mini-instance-example.cfg
@@ -222,7 +222,7 @@ KNOWN_PEERS=[
 #
 #  stellar-core --convertid <seed>
 #
-NODE_SEED="PLACE_SEED_HERE_BEGINS_WITH_G self"
+NODE_SEED="PLACE_SEED_HERE_BEGINS_WITH_S self"
 
 # NODE_IS_VALIDATOR (boolean) default false.
 # Only nodes that want to participate in SCP should set NODE_IS_VALIDATOR=true.


### PR DESCRIPTION
Seed should begin with an S not a G